### PR TITLE
Fixed analytics

### DIFF
--- a/elastic_site_search/client.py
+++ b/elastic_site_search/client.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from .version import VERSION
 
-CLIENT_NAME = 'elastic-app-search-python'
+CLIENT_NAME = 'elastic-site-search-python'
 DEFAULT_API_HOST = 'api.swiftype.com'
 DEFAULT_API_BASE_PATH = '/api/v1/'
 

--- a/fixtures/analytics_autoselects.yaml
+++ b/fixtures/analytics_autoselects.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_autoselects_pagination.yaml
+++ b/fixtures/analytics_autoselects_pagination.yaml
@@ -3,7 +3,7 @@ interactions:
     body: ''
     headers:
       Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
+      X-Swiftype-Client: elastic-site-search-python
       X-Swiftype-Client-Version: 2.0.0
     method: GET
     uri: http://localhost:3000/api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01

--- a/fixtures/analytics_searches.yaml
+++ b/fixtures/analytics_searches.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_searches_pagination.yaml
+++ b/fixtures/analytics_searches_pagination.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-  response:
-    body: {string: '[["2014-01-01",0],["2013-12-31",0]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
+    response:
+      body: { string: '[["2014-01-01",0],["2013-12-31",0]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_top_no_result_queries.yaml
+++ b/fixtures/analytics_top_no_result_queries.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[["foo",2],["bar",1]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key
+    response:
+      body: { string: '[["foo",2],["bar",1]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_top_no_result_queries_with_dates.yaml
+++ b/fixtures/analytics_top_no_result_queries_with_dates.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-  response:
-    body: {string: '[["foo",2],["bar",1]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
+    response:
+      body: { string: '[["foo",2],["bar",1]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_top_queries.yaml
+++ b/fixtures/analytics_top_queries.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?auth_token=a-test-api-key
+    response:
+      body: { string: '[["dostoyevsky",2],["gatsby",1]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_top_queries_in_range.yaml
+++ b/fixtures/analytics_top_queries_in_range.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-  response:
-    body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
+    response:
+      body: { string: '[["dostoyevsky",2],["gatsby",1]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/analytics_top_queries_pagination.yaml
+++ b/fixtures/analytics_top_queries_pagination.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?per_page=10&auth_token=a-test-api-key&page=2
-  response:
-    body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?per_page=10&auth_token=a-test-api-key&page=2
+    response:
+      body: { string: '[["dostoyevsky",2],["gatsby",1]]' }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/crawl_domain.yaml
+++ b/fixtures/crawl_domain.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"url": "http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: PUT
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/crawl_url.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"external_id":"9508ace2e1ba669854eb49fbe9429952ff1a6d4c","url":"http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"url": "http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: PUT
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/crawl_url.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"external_id":"9508ace2e1ba669854eb49fbe9429952ff1a6d4c","url":"http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_document.yaml
+++ b/fixtures/create_document.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"document": {"external_id": "doc_id"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"external_id":"doc_id","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52cb1f823ae7403ec900003e","_id":"52cb1f823ae7403ec900003e","updated_at":"2014-01-06T21:26:26Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"document": {"external_id": "doc_id"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"external_id":"doc_id","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52cb1f823ae7403ec900003e","_id":"52cb1f823ae7403ec900003e","updated_at":"2014-01-06T21:26:26Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_document_type.yaml
+++ b/fixtures/create_document_type.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"document_type": {"name": "videos"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"id":"52cb1ee93ae7403ec900003c","name":"videos","slug":"videos","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-06T21:23:53Z","document_count":0,"field_mapping":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"document_type": {"name": "videos"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"id":"52cb1ee93ae7403ec900003c","name":"videos","slug":"videos","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-06T21:23:53Z","document_count":0,"field_mapping":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_documents.yaml
+++ b/fixtures/create_documents.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[true,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[true,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_domain.yaml
+++ b/fixtures/create_domain.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"domain": {"submitted_url": "http://www.example.com"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"id":"52cb2a8a3ae7403ec9000047","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-06T22:13:30Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"domain": {"submitted_url": "http://www.example.com"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"id":"52cb2a8a3ae7403ec9000047","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-06T22:13:30Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_or_update_document.yaml
+++ b/fixtures/create_or_update_document.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"document": {"fields": {}, "external_id": "1"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/create_or_update.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-06T21:27:02Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"document": {"fields": {}, "external_id": "1"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/create_or_update.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-06T21:27:02Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_or_update_documents.yaml
+++ b/fixtures/create_or_update_documents.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[true,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[true,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_or_update_documents_failure.yaml
+++ b/fixtures/create_or_update_documents_failure.yaml
@@ -1,15 +1,16 @@
 interactions:
-- request:
-    body: '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
-      "1"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[false]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body:
+        '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
+        "1"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[false]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_or_update_documents_verbose.yaml
+++ b/fixtures/create_or_update_documents_verbose.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[true,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[true,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_or_update_documents_verbose_failure.yaml
+++ b/fixtures/create_or_update_documents_verbose_failure.yaml
@@ -1,16 +1,21 @@
 interactions:
-- request:
-    body: '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
-      "1"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
-  response:
-    body: {string: '["Invalid field definition: Field definition requires a ''value''
-        attribute"]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body:
+        '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
+        "1"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string:
+            '["Invalid field definition: Field definition requires a ''value''
+            attribute"]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/create_user.yaml
+++ b/fixtures/create_user.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-  response:
-    body: {string: '{"id":"123456","access_token":"ab169f3343724916d2ccba5e748bdedd6cbf7c06e7d8952530dfa82e1b1052f3"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
+    response:
+      body:
+        {
+          string: '{"id":"123456","access_token":"ab169f3343724916d2ccba5e748bdedd6cbf7c06e7d8952530dfa82e1b1052f3"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/destroy_document.yaml
+++ b/fixtures/destroy_document.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: DELETE
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/doc_id.json?auth_token=a-test-api-key
-  response:
-    body: {string: ''}
-    headers: {}
-    status: {code: 204, message: No Content}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: DELETE
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/doc_id.json?auth_token=a-test-api-key
+    response:
+      body: { string: "" }
+      headers: {}
+      status: { code: 204, message: No Content }
 version: 1

--- a/fixtures/destroy_document_type.yaml
+++ b/fixtures/destroy_document_type.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: DELETE
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/videos.json?auth_token=a-test-api-key
-  response:
-    body: {string: ''}
-    headers: {}
-    status: {code: 204, message: No Content}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: DELETE
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/videos.json?auth_token=a-test-api-key
+    response:
+      body: { string: "" }
+      headers: {}
+      status: { code: 204, message: No Content }
 version: 1

--- a/fixtures/destroy_documents.yaml
+++ b/fixtures/destroy_documents.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: '{"documents": ["doc_id1", "doc_id2"]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_destroy.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[true,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"documents": ["doc_id1", "doc_id2"]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_destroy.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[true,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/destroy_domain.yaml
+++ b/fixtures/destroy_domain.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: DELETE
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
-  response:
-    body: {string: ''}
-    headers: {}
-    status: {code: 204, message: No Content}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: DELETE
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
+    response:
+      body: { string: "" }
+      headers: {}
+      status: { code: 204, message: No Content }
 version: 1

--- a/fixtures/document.yaml
+++ b/fixtures/document.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/1.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/1.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/document_type.yaml
+++ b/fixtures/document_type.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/document_types.yaml
+++ b/fixtures/document_types.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/documents.yaml
+++ b/fixtures/documents.yaml
@@ -1,15 +1,19 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
-        title","author":"Fyodor Dostoevsky","genre":"fiction"}]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string:
+            '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
+            title","author":"Fyodor Dostoevsky","genre":"fiction"}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/documents_pagination.yaml
+++ b/fixtures/documents_pagination.yaml
@@ -1,15 +1,19 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?per_page=10&auth_token=a-test-api-key&page=2
-  response:
-    body: {string: '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
-        title","author":"Fyodor Dostoevsky","genre":"fiction"}]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?per_page=10&auth_token=a-test-api-key&page=2
+    response:
+      body:
+        {
+          string:
+            '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
+            title","author":"Fyodor Dostoevsky","genre":"fiction"}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/domain.yaml
+++ b/fixtures/domain.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/domains.yaml
+++ b/fixtures/domains.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"},{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T18:31:12Z"}]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"},{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T18:31:12Z"}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/engine.yaml
+++ b/fixtures/engine.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/engine_create.yaml
+++ b/fixtures/engine_create.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"engine": {"name": "myengine"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"name":"myengine","slug":"myengine","key":"ziLaAWiqF1VpspxTTp3J","id":"52cb2bda3ae7403ec9000048","_id":"52cb2bda3ae7403ec9000048","updated_at":"2014-01-06T22:19:06Z","document_count":0}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"engine": {"name": "myengine"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"name":"myengine","slug":"myengine","key":"ziLaAWiqF1VpspxTTp3J","id":"52cb2bda3ae7403ec9000048","_id":"52cb2bda3ae7403ec9000048","updated_at":"2014-01-06T22:19:06Z","document_count":0}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/engine_destroy.yaml
+++ b/fixtures/engine_destroy.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: DELETE
-    uri: http://localhost:3000/api/v1/engines/myengine.json?auth_token=a-test-api-key
-  response:
-    body: {string: ''}
-    headers: {}
-    status: {code: 204, message: No Content}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: DELETE
+      uri: http://localhost:3000/api/v1/engines/myengine.json?auth_token=a-test-api-key
+    response:
+      body: { string: "" }
+      headers: {}
+      status: { code: 204, message: No Content }
 version: 1

--- a/fixtures/engines.yaml
+++ b/fixtures/engines.yaml
@@ -1,15 +1,19 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2},{"name":"Crawler
-        Demo","slug":"crawler-demo","key":"whYbNeFx9D1PQg8xXv8H","id":"52c74ea83ae7403ec9000032","_id":"52c74ea83ae7403ec9000032","updated_at":"2014-01-03T23:58:37Z","document_count":17},{"name":"engine","slug":"engine","key":"zicsWdgY3hFLqqQGRBg1","id":"52c73b833ae7403ec9000012","_id":"52c73b833ae7403ec9000012","updated_at":"2014-01-03T22:36:51Z","document_count":0}]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string:
+            '[{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2},{"name":"Crawler
+            Demo","slug":"crawler-demo","key":"whYbNeFx9D1PQg8xXv8H","id":"52c74ea83ae7403ec9000032","_id":"52c74ea83ae7403ec9000032","updated_at":"2014-01-03T23:58:37Z","document_count":17},{"name":"engine","slug":"engine","key":"zicsWdgY3hFLqqQGRBg1","id":"52c73b833ae7403ec9000012","_id":"52c73b833ae7403ec9000012","updated_at":"2014-01-03T22:36:51Z","document_count":0}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/platform_create_document.yaml
+++ b/fixtures/platform_create_document.yaml
@@ -1,15 +1,21 @@
 interactions:
-- request:
-    body: '{"document": {"external_id": "doc_id"}}'
-    headers:
-      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents.json
-  response:
-    body: {string: '{"external_id":"doc_id","engine_id":"52cca3f13ae740f4af000023","document_type_id":"52cca4a43ae740f4af000024","id":"52cca54f3ae740f4af000026","_id":"52cca54f3ae740f4af000026","updated_at":"2014-01-08T01:09:35Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"document": {"external_id": "doc_id"}}'
+      headers:
+        Authorization:
+          [
+            Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e,
+          ]
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents.json
+    response:
+      body:
+        {
+          string: '{"external_id":"doc_id","engine_id":"52cca3f13ae740f4af000023","document_type_id":"52cca4a43ae740f4af000024","id":"52cca54f3ae740f4af000026","_id":"52cca54f3ae740f4af000026","updated_at":"2014-01-08T01:09:35Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/platform_create_document_type.yaml
+++ b/fixtures/platform_create_document_type.yaml
@@ -1,15 +1,21 @@
 interactions:
-- request:
-    body: '{"document_type": {"name": "videos"}}'
-    headers:
-      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types.json
-  response:
-    body: {string: '{"id":"52cca4a43ae740f4af000024","name":"videos","slug":"videos","engine_id":"52cca3f13ae740f4af000023","updated_at":"2014-01-08T01:06:44Z","document_count":0,"field_mapping":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"document_type": {"name": "videos"}}'
+      headers:
+        Authorization:
+          [
+            Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e,
+          ]
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/myusersengine/document_types.json
+    response:
+      body:
+        {
+          string: '{"id":"52cca4a43ae740f4af000024","name":"videos","slug":"videos","engine_id":"52cca3f13ae740f4af000023","updated_at":"2014-01-08T01:06:44Z","document_count":0,"field_mapping":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/platform_create_documents.yaml
+++ b/fixtures/platform_create_documents.yaml
@@ -1,15 +1,18 @@
 interactions:
-- request:
-    body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
-    headers:
-      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents/bulk_create.json
-  response:
-    body: {string: '[true,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
+      headers:
+        Authorization:
+          [
+            Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e,
+          ]
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents/bulk_create.json
+    response:
+      body: { string: "[true,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/platform_engine_create.yaml
+++ b/fixtures/platform_engine_create.yaml
@@ -1,15 +1,21 @@
 interactions:
-- request:
-    body: '{"engine": {"name": "myusersengine"}}'
-    headers:
-      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: POST
-    uri: http://localhost:3000/api/v1/engines.json
-  response:
-    body: {string: '{"name":"myusersengine","slug":"myusersengine","key":"wLDDEvF4GetXAkx6xiss","id":"52ccaa333ae740f4af00002b","_id":"52ccaa333ae740f4af00002b","updated_at":"2014-01-08T01:30:27Z","document_count":0}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"engine": {"name": "myusersengine"}}'
+      headers:
+        Authorization:
+          [
+            Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e,
+          ]
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: POST
+      uri: http://localhost:3000/api/v1/engines.json
+    response:
+      body:
+        {
+          string: '{"name":"myusersengine","slug":"myusersengine","key":"wLDDEvF4GetXAkx6xiss","id":"52ccaa333ae740f4af00002b","_id":"52ccaa333ae740f4af00002b","updated_at":"2014-01-08T01:30:27Z","document_count":0}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/platform_engine_destroy.yaml
+++ b/fixtures/platform_engine_destroy.yaml
@@ -1,15 +1,18 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: DELETE
-    uri: http://localhost:3000/api/v1/engines/myuserengine.json
-  response:
-    body: {string: '{"error":"Permission denied."}'}
-    headers: {}
-    status: {code: 403, message: Forbidden}
+  - request:
+      body: ""
+      headers:
+        Authorization:
+          [
+            Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e,
+          ]
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: DELETE
+      uri: http://localhost:3000/api/v1/engines/myuserengine.json
+    response:
+      body: { string: '{"error":"Permission denied."}' }
+      headers: {}
+      status: { code: 403, message: Forbidden }
 version: 1

--- a/fixtures/recrawl_domain.yaml
+++ b/fixtures/recrawl_domain.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: PUT
-    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/recrawl.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T22:17:01Z"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: PUT
+      uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/recrawl.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T22:17:01Z"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/search.yaml
+++ b/fixtures/search.yaml
@@ -1,26 +1,32 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {}
-    status: {code: 200, message: OK}
-- request:
-    body: '{"q": "*"}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/search.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"records":{"responses":[],"books":[]},"info":{"responses":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}},"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
+  - request:
+      body: '{"q": "*"}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/search.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"records":{"responses":[],"books":[]},"info":{"responses":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}},"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/search_document_type.yaml
+++ b/fixtures/search_document_type.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"q": "*"}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"records":{"books":[]},"info":{"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"q": "*"}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"records":{"books":[]},"info":{"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/search_document_type_with_options.yaml
+++ b/fixtures/search_document_type_with_options.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"q": "query", "page": 2}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"q": "query", "page": 2}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/search_with_options.yaml
+++ b/fixtures/search_with_options.yaml
@@ -3,7 +3,7 @@ interactions:
     body: ''
     headers:
       Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
+      X-Swiftype-Client: elastic-site-search-python
       X-Swiftype-Client-Version: 2.0.0
     method: GET
     uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
@@ -15,7 +15,7 @@ interactions:
     body: '{"q": "query", "page": 2}'
     headers:
       Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
+      X-Swiftype-Client: elastic-site-search-python
       X-Swiftype-Client-Version: 2.0.0
     method: GET
     uri: http://localhost:3000/api/v1/engines/api-test/search.json?auth_token=a-test-api-key

--- a/fixtures/suggest.yaml
+++ b/fixtures/suggest.yaml
@@ -1,26 +1,32 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {}
-    status: {code: 200, message: OK}
-- request:
-    body: '{"q": "*"}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
+  - request:
+      body: '{"q": "*"}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/suggest_document_type.yaml
+++ b/fixtures/suggest_document_type.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"q": "*"}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"record_count":0,"records":{"books":[]},"info":{},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"q": "*"}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"record_count":0,"records":{"books":[]},"info":{},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/suggest_document_type_with_options.yaml
+++ b/fixtures/suggest_document_type_with_options.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: '{"q": "query", "page": 2}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"record_count":0,"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"q": "query", "page": 2}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"record_count":0,"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/suggest_with_options.yaml
+++ b/fixtures/suggest_with_options.yaml
@@ -1,26 +1,32 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {}
-    status: {code: 200, message: OK}
-- request:
-    body: '{"q": "query", "page": 2}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{"responses":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0},"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
+  - request:
+      body: '{"q": "query", "page": 2}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{"responses":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0},"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/update_document.yaml
+++ b/fixtures/update_document.yaml
@@ -1,15 +1,19 @@
 interactions:
-- request:
-    body: '{"fields": {"title": "a new title"}}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: PUT
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/2/update_fields.json?auth_token=a-test-api-key
-  response:
-    body: {string: '{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-06T21:27:40Z","title":"a
-        new title","author":"Fyodor Dostoevsky","genre":"fiction"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: '{"fields": {"title": "a new title"}}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: PUT
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/2/update_fields.json?auth_token=a-test-api-key
+    response:
+      body:
+        {
+          string:
+            '{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-06T21:27:40Z","title":"a
+            new title","author":"Fyodor Dostoevsky","genre":"fiction"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/update_documents.yaml
+++ b/fixtures/update_documents.yaml
@@ -1,15 +1,16 @@
 interactions:
-- request:
-    body: '{"documents": [{"fields": {"myfieldthathasnotbeencreated": "foobar"}, "external_id":
-      "1"}, {"fields": {"title": "new title"}, "external_id": "2"}]}'
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: PUT
-    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_update.json?auth_token=a-test-api-key
-  response:
-    body: {string: '[false,true]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body:
+        '{"documents": [{"fields": {"myfieldthathasnotbeencreated": "foobar"}, "external_id":
+        "1"}, {"fields": {"title": "new title"}, "external_id": "2"}]}'
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: PUT
+      uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_update.json?auth_token=a-test-api-key
+    response:
+      body: { string: "[false,true]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/user.yaml
+++ b/fixtures/user.yaml
@@ -1,14 +1,17 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/users/12345.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-  response:
-    body: {string: '{"id":"12345","access_token":"ab37d7821853d6be1d7c451b449064ccf55300fdd5157baed48af53fd52b61f5"}'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/users/12345.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
+    response:
+      body:
+        {
+          string: '{"id":"12345","access_token":"ab37d7821853d6be1d7c451b449064ccf55300fdd5157baed48af53fd52b61f5"}',
+        }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -3,7 +3,7 @@ interactions:
     body: ''
     headers:
       Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
+      X-Swiftype-Client: elastic-site-search-python
       X-Swiftype-Client-Version: 2.0.0
     method: GET
     uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9

--- a/fixtures/users_pagination.yaml
+++ b/fixtures/users_pagination.yaml
@@ -1,14 +1,14 @@
 interactions:
-- request:
-    body: ''
-    headers:
-      Content-Type: [application/json]
-      X-Swiftype-Client: elastic-app-search-python
-      X-Swiftype-Client-Version: 2.0.0
-    method: GET
-    uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&page=2&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-  response:
-    body: {string: '[]'}
-    headers: {}
-    status: {code: 200, message: OK}
+  - request:
+      body: ""
+      headers:
+        Content-Type: [application/json]
+        X-Swiftype-Client: elastic-site-search-python
+        X-Swiftype-Client-Version: 2.0.0
+      method: GET
+      uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&page=2&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
+    response:
+      body: { string: "[]" }
+      headers: {}
+      status: { code: 200, message: OK }
 version: 1


### PR DESCRIPTION
This client was reporting itself as "app search", instead of "site
search".

I updated any reference of "elastic-app-search-python" with "elastic-site-search-python".

NOTE: Auto-formatter did some work on these files, be sure to turn off white space diffs when you view this.